### PR TITLE
Fix gpg: keyserver receive failed error.

### DIFF
--- a/.github/workflows/deploy-ubuntu-images-to-dockerhub.yml
+++ b/.github/workflows/deploy-ubuntu-images-to-dockerhub.yml
@@ -10,6 +10,20 @@ on:
       - '**/deploy-ubuntu-images-to-dockerhub.yml'
 
 jobs:
+  ubuntu-latest-push:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Publish Ubuntu:latest to Registry
+      uses: elgohr/Publish-Docker-Github-Action@2.12
+      with:
+        name: daniccan/ubuntu-gosu
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        dockerfile: Ubuntu.Dockerfile
+        buildargs: OS_VERSION=latest
+        tags: latest
+
   ubuntu-18_04-push:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ docker run -it -e LOCAL_USER_ID=`id -u $USER` your-image
 
 ### Supported Linux Distros
 
-| Linux Distro         | Version(s)                                      | Docker Repo                                                           |
-|----------------------|-------------------------------------------------|-----------------------------------------------------------------------|
-| Ubuntu               | 18.04 (bionic), 16.04 (xenial), 14.04 (trusty)  | [daniccan/ubuntu-gosu](https://hub.docker.com/r/daniccan/ubuntu-gosu) |
-| CentOS               | 6, 7, 8                                         | [daniccan/centos-gosu](https://hub.docker.com/r/daniccan/centos-gosu) |
+| Linux Distro         | Version(s)                                              | Docker Repo                                                           |
+|----------------------|---------------------------------------------------------|-----------------------------------------------------------------------|
+| Ubuntu               | latest, 18.04 (bionic), 16.04 (xenial), 14.04 (trusty)  | [daniccan/ubuntu-gosu](https://hub.docker.com/r/daniccan/ubuntu-gosu) |
+| CentOS               | 6, 7, 8                                                 | [daniccan/centos-gosu](https://hub.docker.com/r/daniccan/centos-gosu) |
 
 ### Issues
 

--- a/Ubuntu.Dockerfile
+++ b/Ubuntu.Dockerfile
@@ -4,10 +4,13 @@ FROM ubuntu:$OS_VERSION
 
 LABEL maintainer "https://github.com/daniccan"
 
-RUN apt-get update && apt-get -y --no-install-recommends install \
-    gnupg \
+RUN apt-get update && apt-get -y install \
     ca-certificates \
     curl
+
+# Ubuntu 18.04+ maps gnupg to version 2.x instead of version 1.x
+# Fixes gpg: keyserver receive failed: Server indicated a failure
+RUN (apt-get -y install gnupg1 && echo "alias gpg=gpg1" >> ~/.bashrc && source ~/.bashrc) || apt-get -y install gnupg
 
 ENV USERNAME ubuntu
 ENV GOSU_VERSION 1.11
@@ -15,9 +18,10 @@ ENV GOSU_DOWNLOAD_URL https://github.com/tianon/gosu/releases/download
 ENV GOSU_BINARY "${GOSU_DOWNLOAD_URL}/${GOSU_VERSION}/gosu"
 ENV GPG_KEY B42F6819007F00F88E364FD4036A9C25BF357DD4
 
+RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY"
+
 RUN curl -o /usr/local/bin/gosu -SL "$GOSU_BINARY-$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
     && curl -o /usr/local/bin/gosu.asc -SL "$GOSU_BINARY-$(dpkg --print-architecture | awk -F- '{ print $NF }').asc" \
-    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$GPG_KEY" \
     && gpg --verify /usr/local/bin/gosu.asc \
     && rm /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu


### PR DESCRIPTION
## Description
Fix gpg: keyserver receive failed error. Use `gnupg1` instead of `gnupg` for Ubuntu version 18.04+.
